### PR TITLE
Update tctl version and modify login and readme

### DIFF
--- a/tctl-snap/README.md
+++ b/tctl-snap/README.md
@@ -22,6 +22,17 @@ make all
 sudo snap install tctl_next_amd64.snap --dangerous
 ```
 
+Note: By default, the tctl snap is installed with the `next` version, which is
+not recommended for production environments. Run the following command to switch
+to the stable `v1` version:
+
+```bash
+tctl.<env> config set version current # replace <env> with dev, stg or prod
+
+# Verify version
+tctl.<env> --version
+```
+
 tctl commands can be run in the following pre-defined three environments:
 
 - `dev`: This environment does not have the authorization plugin enabled and
@@ -46,7 +57,7 @@ tctl commands can be run in the following pre-defined three environments:
   tctl.stg login
 
   # Include Temporal server address flag in the command
-  tct.stg --address=<server_hostname>:443 --tls-server-name=<server_hostname> namespace list
+  tct.stg --address=<server_hostname>:443 --tls_server_name=<server_hostname> namespace list
   ```
 
 - `prod`: This is a production environment with the authorization plugin
@@ -64,7 +75,7 @@ tctl commands can be run in the following pre-defined three environments:
   tctl.prod login
 
   # Include Temporal server address flag in the command
-  tct.prod --address=<server_hostname>:443 --tls-server-name=<server_hostname> namespace list
+  tct.prod --address=<server_hostname>:443 --tls_server_name=<server_hostname> namespace list
   ```
 
   Some sample operations that can be run in any environment also include:
@@ -84,7 +95,7 @@ tctl commands can be run in the following pre-defined three environments:
 
   Note: the --tls-server-name flag must be included if TLS is enabled on your
   deployment through ingress. To avoid having to include the `address` and
-  `tls-server-name` modifiers with every command, you can export the environment
+  `tls_server_name` modifiers with every command, you can export the environment
   variables `TEMPORAL_CLI_ADDRESS` and `TEMPORAL_CLI_TLS_SERVER_NAME` and run
   the `tctl` command without any modifiers. More information can be found
   [here](https://docs.temporal.io/tctl-v1#environment-variables).

--- a/tctl-snap/README.md
+++ b/tctl-snap/README.md
@@ -9,6 +9,8 @@ user-specific access token to be attached with each request made to the Temporal
 server. For more information on how to obtain Google credentials for your
 project, visit
 [Google Cloud Platform Help](https://support.google.com/cloud/answer/6158849?hl=en#zippy=%2Cnative-applications%2Cdesktop-apps).
+For the created web application, you must add
+`http://localhost:5000/oauth2callback` as one of the authorized redirect URIs.
 
 The snap can be installed as follows:
 
@@ -44,7 +46,7 @@ tctl commands can be run in the following pre-defined three environments:
   tctl.stg login
 
   # Include Temporal server address flag in the command
-  tct.stg --address=localhost:7233 namespace list
+  tct.stg --address=<server_hostname>:443 --tls-server-name=<server_hostname> namespace list
   ```
 
 - `prod`: This is a production environment with the authorization plugin
@@ -62,7 +64,7 @@ tctl commands can be run in the following pre-defined three environments:
   tctl.prod login
 
   # Include Temporal server address flag in the command
-  tct.prod --address=localhost:7233 namespace list
+  tct.prod --address=<server_hostname>:443 --tls-server-name=<server_hostname> namespace list
   ```
 
   Some sample operations that can be run in any environment also include:
@@ -79,3 +81,10 @@ tctl commands can be run in the following pre-defined three environments:
   ```
 
   Other commands can be found [here](https://docs.temporal.io/tctl-v1).
+
+  Note: the --tls-server-name flag must be included if TLS is enabled on your
+  deployment through ingress. To avoid having to include the `address` and
+  `tls-server-name` modifiers with every command, you can export the environment
+  variables `TEMPORAL_CLI_ADDRESS` and `TEMPORAL_CLI_TLS_SERVER_NAME` and run
+  the `tctl` command without any modifiers. More information can be found
+  [here](https://docs.temporal.io/tctl-v1#environment-variables).

--- a/tctl-snap/README.md
+++ b/tctl-snap/README.md
@@ -15,9 +15,11 @@ For the created web application, you must add
 The snap can be installed as follows:
 
 ```bash
-# Build snap
-make all
+# Option 1: Install from SnapStore
+sudo snap install tctl
 
+#Option 2 (development): Build snap
+make all
 # Install snap
 sudo snap install tctl_next_amd64.snap --dangerous
 ```
@@ -40,7 +42,7 @@ tctl commands can be run in the following pre-defined three environments:
   empty authorization header. The following is an example command:
 
   ```bash
-  tctl.dev namespace list
+  tctl.dev --address=localhost:7233 namespace list
   ```
 
 - `stg`: This is a staging environment with the authorization plugin enabled. It
@@ -93,7 +95,7 @@ tctl commands can be run in the following pre-defined three environments:
 
   Other commands can be found [here](https://docs.temporal.io/tctl-v1).
 
-  Note: the --tls-server-name flag must be included if TLS is enabled on your
+  Note: the --tls_server_name flag must be included if TLS is enabled on your
   deployment through ingress. To avoid having to include the `address` and
   `tls_server_name` modifiers with every command, you can export the environment
   variables `TEMPORAL_CLI_ADDRESS` and `TEMPORAL_CLI_TLS_SERVER_NAME` and run

--- a/tctl-snap/tctl-plugins/cmd/cmd.go
+++ b/tctl-snap/tctl-plugins/cmd/cmd.go
@@ -64,10 +64,6 @@ func FetchValidToken(clientID string, clientSecret string) (string, error) {
 	path := os.Getenv("SNAP_USER_DATA")
 	accessToken, err := readTokenFromFile(path, "access")
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			fmt.Fprintf(os.Stderr, "error reading access token from file at path: %v, %v", path, err)
-		}
-
 		return "", err
 	}
 
@@ -160,14 +156,7 @@ func readTokenFromFile(directory string, token_type string) (string, error) {
 	data, err := ioutil.ReadFile(filePath)
 
 	if err != nil {
-		if pathErr, ok := err.(*os.PathError); ok {
-			// Check if file does not exist
-			if pathErr.Err == os.ErrNotExist {
-				return "", os.ErrNotExist
-			}
-		}
-
-		return "", err
+		return "", fmt.Errorf("No valid token found. Please use tctl.%v login.", env)
 	}
 
 	token := string(data)
@@ -233,7 +222,7 @@ func refreshAccessToken(clientID string, clientSecret string, refreshToken strin
 	defer response.Body.Close()
 
 	if response.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("token refresh failed with status code: %d", response.StatusCode)
+		return nil, fmt.Errorf("token refresh failed with status code: %d. please retry login.", response.StatusCode)
 	}
 
 	var tokenResp tokenResponse

--- a/tctl-snap/tctl-plugins/cmd/tctl-login/login.go
+++ b/tctl-snap/tctl-plugins/cmd/tctl-login/login.go
@@ -9,7 +9,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -70,28 +69,10 @@ func main() {
 	}
 }
 
-// getFreePort returns an available TCP port number on the localhost.
-func getFreePort() (int, error) {
-	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
-	if err != nil {
-		return 0, err
-	}
-	l, err := net.ListenTCP("tcp", addr)
-	if err != nil {
-		return 0, err
-	}
-	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port, nil
-}
-
 // getToken returns a valid Google OAuth 2.0 access token.
 func getToken() error {
 	ctx := context.Background()
-	port, err := getFreePort()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error getting free port: %s\n", err)
-		return err
-	}
+	port := 5000
 
 	redirectURI = fmt.Sprintf("http://localhost:%v/oauth2callback", port)
 	authURL := generateAuthURL()


### PR DESCRIPTION
This PR addresses the following:
- Updates tctl version to latest branch.
- Modifies the tctl snap's README to include a necessary flag for running commands in staging and production environments.
- Fixes the login service's port to `5000` rather than generating a new one at every login, as this URI needs to be included on the Google Cloud application for it to work.
- Improves error message for when a valid token is not found.